### PR TITLE
Add 'Open next'/'Open previous' file shortcuts for fast directory browsing

### DIFF
--- a/pimsviewer/viewer.py
+++ b/pimsviewer/viewer.py
@@ -12,13 +12,14 @@ import warnings
 import numpy as np
 import pims
 from pims import FramesSequence, FramesSequenceND
+from pims.utils.sort import natural_keys
 
 from .widgets import CheckBox, DockWidget, VideoTimer, Slider
 from .qt import (Qt, QtWidgets, QtGui, QtCore, Signal,
                  init_qtapp, start_qtapp)
 from .display import Display
 from .utils import (wrap_frames_sequence, recursive_subclasses,
-                    to_rgb_uint8)
+                    to_rgb_uint8, memoize)
 
 try:
     with warnings.catch_warnings():
@@ -706,8 +707,9 @@ class Viewer(QtWidgets.QMainWindow):
         clipboard.setPixmap(self.to_pixmap())
 
     @staticmethod
+    @memoize
     def _get_all_files_in_dir(directory):
-        return [f for f in listdir(directory) if isfile(join(directory, f))]
+        return sorted([f for f in listdir(directory) if isfile(join(directory, f))], key=natural_keys)
 
     #
     # def to_frame(self):

--- a/pimsviewer/viewer.py
+++ b/pimsviewer/viewer.py
@@ -708,50 +708,51 @@ class Viewer(QtWidgets.QMainWindow):
     @staticmethod
     def _get_all_files_in_dir(directory):
         return [f for f in listdir(directory) if isfile(join(directory, f))]
-        #
-        # def to_frame(self):
-        #     return Frame(rgb_view(self.to_pixmap().toImage()),
-        #                  frame_no=self.index['t'])
-        #
-        # def save_file(self, filename=None):
-        #     str_filter = ";;".join(['All files (*.*)',
-        #                             'H264 video (*.avi)',
-        #                             'MPEG4 video (*.mp4 *.mov)',
-        #                             'Windows Media Player video (*.wmv)'])
-        #
-        #
-        #     if VideoClip is None:
-        #         raise ImportError('The MoviePy exporter requires moviepy to work.')
-        #
-        #     if filename is None:
-        #         try:
-        #             cur_dir = os.path.dirname(self.reader.filename)
-        #         except AttributeError:
-        #             cur_dir = ''
-        #         filename = QtWidgets.QFileDialog.getSaveFileName(self,
-        #                                                          "Export Movie",
-        #                                                          cur_dir,
-        #                                                          str_filter)
-        #         if isinstance(filename, tuple):
-        #             # Handle discrepancy between PyQt4 and PySide APIs.
-        #             filename = filename[0]
-        #
-        #     _, ext = os.path.splitext(os.path.basename(filename))
-        #     ext = ext[1:].lower()
-        #     if ext == 'wmv':
-        #         codec = 'wmv2'
-        #     else:
-        #         codec = None  # let moviepy decide
-        #     if ext == '':
-        #         filename += '.mp4'
-        #
-        #     try:
-        #         rate = self.reader.frame_rate
-        #     except AttributeError:
-        #         rate = 25
-        #
-        #     self.reader.iter_axes = ['t']
-        #     self.status = 'Saving to {}'.format(filename)
-        #     pims.export(self.reader, filename, rate, codec=codec)
-        #     self.update_image()
-        #     self.status = 'Done saving {}'.format(filename)
+
+    #
+    # def to_frame(self):
+    #     return Frame(rgb_view(self.to_pixmap().toImage()),
+    #                  frame_no=self.index['t'])
+    #
+    # def save_file(self, filename=None):
+    #     str_filter = ";;".join(['All files (*.*)',
+    #                             'H264 video (*.avi)',
+    #                             'MPEG4 video (*.mp4 *.mov)',
+    #                             'Windows Media Player video (*.wmv)'])
+    #
+    #
+    #     if VideoClip is None:
+    #         raise ImportError('The MoviePy exporter requires moviepy to work.')
+    #
+    #     if filename is None:
+    #         try:
+    #             cur_dir = os.path.dirname(self.reader.filename)
+    #         except AttributeError:
+    #             cur_dir = ''
+    #         filename = QtWidgets.QFileDialog.getSaveFileName(self,
+    #                                                          "Export Movie",
+    #                                                          cur_dir,
+    #                                                          str_filter)
+    #         if isinstance(filename, tuple):
+    #             # Handle discrepancy between PyQt4 and PySide APIs.
+    #             filename = filename[0]
+    #
+    #     _, ext = os.path.splitext(os.path.basename(filename))
+    #     ext = ext[1:].lower()
+    #     if ext == 'wmv':
+    #         codec = 'wmv2'
+    #     else:
+    #         codec = None  # let moviepy decide
+    #     if ext == '':
+    #         filename += '.mp4'
+    #
+    #     try:
+    #         rate = self.reader.frame_rate
+    #     except AttributeError:
+    #         rate = 25
+    #
+    #     self.reader.iter_axes = ['t']
+    #     self.status = 'Saving to {}'.format(filename)
+    #     pims.export(self.reader, filename, rate, codec=codec)
+    #     self.update_image()
+    #     self.status = 'Done saving {}'.format(filename)


### PR DESCRIPTION
I have added two menu items:

1. Open next (Ctrl.+Shift+O)
2. Open previous (Alt+Shift+O)

When no file is opened, the standard open function is called. When a file is open, the next/previous file in the directory is opened using the standard open function.

This allows for fast browsing through a directory of multiple image and/or video files.