### PR TITLE
Cli executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,22 @@ Also, it exposes a matplotlib plotting area on which images can be (dynamically)
 annotated, making use of the `Plugin` infrastructure.
 
 ## Starting the viewer
-You can start the viewer as follows:
+
+After installing the viewer, an executable `pimsviewer` is available. Simply run the command via your terminal/command line interface.
+It is also possible to specify a reader. `pimsviewer --help` will list all installed readers, for example:
+
+```
+$ pimsviewer --help
+Usage: pimsviewer [OPTIONS] [FILE]
+
+Options:
+  --reader-class [ImageSequenceND|NorpixSeq|SpeStack|TiffStack_pil|MoviePyReader|ImageReaderND|ReaderSequence|ImageIOReader|ImageSequence|TiffStack_tifffile|TiffSeries|TiffStack_libtiff|BioformatsReader|PyAVReaderTimed|PyAVReaderIndexed|MM_TiffStack|ImageReader|FramesSequenceND|Cine]
+                                  Reader with which to open the file.
+  --help                          Show this message and exit.
+```
+
+## Using the viewer from Python
+You can use the viewer in a Python script as follows:
 
 ```
 from pimsviewer import Viewer

--- a/pimsviewer/run_gui.py
+++ b/pimsviewer/run_gui.py
@@ -4,8 +4,33 @@ except ImportError(ND2Reader):
     pass
 
 from pimsviewer import Viewer
+from pimsviewer.utils import get_available_readers
+import click
 
 
-def run():
+def get_available_readers_dict():
+    available_reader_classes = get_available_readers()
+    available_readers = {cls.__name__: cls for cls in available_reader_classes}
+    return available_readers
+
+
+@click.command()
+@click.argument('file', required=False)
+@click.option('--reader-class', type=click.Choice(get_available_readers_dict().keys()),
+              help='Reader with which to open the file.')
+def run(file, reader_class):
     viewer = Viewer()
+
+    if file is not None:
+        if reader_class is not None:
+            reader = get_available_readers_dict()[reader_class]
+        else:
+            reader = None
+
+        viewer.open_file(filename=file, reader_cls=reader)
+
     viewer.show()
+
+
+if __name__ == '__main__':
+    run()

--- a/pimsviewer/run_gui.py
+++ b/pimsviewer/run_gui.py
@@ -5,5 +5,7 @@ except ImportError(ND2Reader):
 
 from pimsviewer import Viewer
 
-viewer = Viewer()
-viewer.show()
+
+def run():
+    viewer = Viewer()
+    viewer.show()

--- a/pimsviewer/run_gui.py
+++ b/pimsviewer/run_gui.py
@@ -1,8 +1,3 @@
-try:
-    from nd2reader import ND2Reader
-except ImportError(ND2Reader):
-    pass
-
 from pimsviewer import Viewer
 from pimsviewer.utils import get_available_readers
 import click

--- a/pimsviewer/viewer.py
+++ b/pimsviewer/viewer.py
@@ -232,6 +232,7 @@ class Viewer(QtWidgets.QMainWindow):
         if filename is None or len(filename) == 0:
             return
 
+        filename = path.abspath(filename)
         if reader_cls is None:
             try:
                 reader = pims.open(filename)

--- a/pimsviewer/viewer.py
+++ b/pimsviewer/viewer.py
@@ -23,7 +23,7 @@ from .qt import (Qt, QtWidgets, QtGui, QtCore, Signal,
                  init_qtapp, start_qtapp)
 from .display import Display
 from .utils import (wrap_frames_sequence, recursive_subclasses,
-                    to_rgb_uint8, memoize, get_supported_extensions, drop_dot)
+                    to_rgb_uint8, memoize, get_supported_extensions, drop_dot, get_available_readers)
 
 try:
     with warnings.catch_warnings():
@@ -79,10 +79,7 @@ class Viewer(QtWidgets.QMainWindow):
 
         # list all pims reader classed in the "Open with" menu
         open_with_menu = QtWidgets.QMenu('Open with', self)
-        for cls in set(chain(recursive_subclasses(FramesSequence),
-                             recursive_subclasses(FramesSequenceND))):
-            if hasattr(cls, 'no_reader'):
-                continue
+        for cls in get_available_readers():
             open_with_menu.addAction(cls.__name__,
                                      partial(self.open_file, reader_cls=cls))
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup_parameters = dict(
     author_email="caspervdw@gmail.com",
     url="https://github.com/soft-matter/pimsviewer",
     install_requires=['scikit-image>=0.11', 'matplotlib', 'pims>=0.4',
-                      'pillow'],
+                      'pillow', 'click'],
     packages=['pimsviewer'],
     long_description=descr,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,11 @@ setup_parameters = dict(
                       'pillow'],
     packages=['pimsviewer'],
     long_description=descr,
+    entry_points={
+        'gui_scripts': [
+            'pimsviewer=pimsviewer.run_gui:run',
+        ],
+    },
 )
 
 setup(**setup_parameters)


### PR DESCRIPTION
I added the `entry_points` option to the `setup.py` which can automatically register the package as an executable.

I also used the [Click](http://click.pocoo.org/5/) package to provide a command line interface to this executable.

After installing, an executable `pimsviewer` will be available:

```
pimsviewer --help
Usage: pimsviewer [OPTIONS] [FILE]

Options:
  --reader-class [SpeStack|ND2Reader|ImageIOReader|TiffSeries|NorpixSeq|ImageReader|PyAVReaderTimed|BioformatsReader|ReaderSequence|TiffStack_tifffile|TiffStack_pil|ImageSequenceND|MoviePyReader|ImageReaderND|TiffStack_libtiff|PyAVReaderIndexed|ImageSequence|Cine|MM_TiffStack|FramesSequenceND]
                                  Reader with which to open the file.
  --help                          Show this message and exit.
```

You can (optionally) choose a reader from the installed readers on your system and (optionally) provide a file path to open.