### PR TITLE
Fix error when FPS is NaN

### DIFF
--- a/pimsviewer/widgets.py
+++ b/pimsviewer/widgets.py
@@ -32,7 +32,7 @@ class VideoTimer(QtCore.QTimer):
         return 1 / self._interval
     @fps.setter
     def fps(self, value):
-        if value is None or math.isnan(value):
+        if value is None or not np.isfinite(value):
             value = 25.
         self._interval = 1 / value
         self.setInterval(abs(self._interval) * 1000)

--- a/pimsviewer/widgets.py
+++ b/pimsviewer/widgets.py
@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 from pimsviewer.qt import Qt, QtWidgets, QtCore, QtGui, Signal
 from time import time
+import math
 
 from skimage.viewer.widgets import BaseWidget, CheckBox, Text, ComboBox
 
@@ -31,7 +32,7 @@ class VideoTimer(QtCore.QTimer):
         return 1 / self._interval
     @fps.setter
     def fps(self, value):
-        if value is None:
+        if value is None or math.isnan(value):
             value = 25.
         self._interval = 1 / value
         self.setInterval(abs(self._interval) * 1000)


### PR DESCRIPTION
Also check for NaN in the FPS to prevent pimsviewer from crashing.