### PR TITLE
Matplotlib toolbar + cleanup shortcut code

### DIFF
--- a/pimsviewer/display.py
+++ b/pimsviewer/display.py
@@ -65,27 +65,11 @@ class Display(object):
         self.canvas.close()
 
     def resize(self, w, h):
-        self.set_fullscreen(False)
         self.canvas.resize(w, h)
         self.canvas.updateGeometry()
         self.viewer.main_widget.adjustSize()
         self.viewer.main_widget.updateGeometry()
         self.viewer.adjustSize()
-
-    def set_fullscreen(self, value=None):
-        is_fullscreen = self.canvas.isFullScreen()
-        if value is None:
-            value = not is_fullscreen
-        elif value == is_fullscreen:
-            return
-        if value:
-            self.canvas.setWindowFlags(Qt.Window)
-            self.canvas.setWindowState(Qt.WindowFullScreen)
-            self.canvas.show()
-        else:
-            self.canvas.setWindowState(Qt.WindowNoState)
-            self.canvas.setWindowFlags(Qt.Widget)
-            self.canvas.show()
 
     def on_motion(self, event):
         try:

--- a/pimsviewer/display.py
+++ b/pimsviewer/display.py
@@ -1,6 +1,5 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import six
 
 import numpy as np
 from pimsviewer.qt import Qt, FigureCanvasQTAgg
@@ -45,12 +44,10 @@ class Display(object):
         self.ax.set_ylim(h, 0)
 
         self.canvas.mpl_connect('motion_notify_event', self.on_motion)
-        self.canvas.mpl_connect('button_press_event', self.on_press)
         self.canvas.mpl_connect('scroll_event', self.on_scroll)
 
         self.canvas.setFocusPolicy(Qt.ClickFocus)
         self.canvas.setFocus()
-        self.control_is_held = False
 
     def redraw(self):
         self.canvas.draw()
@@ -90,92 +87,6 @@ class Display(object):
             self.canvas.setWindowFlags(Qt.Widget)
             self.canvas.show()
 
-    def zoom(self, step=None, center=None):
-        # get the current x and y limits
-        cur_xlim = self.ax.get_xlim()
-        cur_ylim = self.ax.get_ylim()
-        cur_width = cur_xlim[1] - cur_xlim[0]
-        cur_height = cur_ylim[0] - cur_ylim[1]  # y-axis is inverted
-        max_height, max_width = self.shape
-
-        if center is None:
-            y = (cur_ylim[0] + cur_ylim[1]) / 2
-            x = (cur_xlim[0] + cur_xlim[1]) / 2
-        else:
-            y, x = center
-
-        if x < 0 or y < 0 or x > max_width or y > max_height:
-            return
-        if step is None:
-            scale_factor = min(max_width/cur_width, max_height/cur_height)
-        else:
-            scale_factor = min(0.8**step, max_width/cur_width,
-                               max_height/cur_height)
-        if scale_factor == 1.:
-            return
-        # calculate new limits
-        w = scale_factor*(cur_xlim[1] - cur_xlim[0])
-        h = scale_factor*(cur_ylim[0] - cur_ylim[1])  # y-axis is inverted
-        x -= w / 2
-        y -= h / 2
-
-        # shift box if any corner is out of bounds
-        if x < 0:
-            x = 0
-        if y < 0:
-            y = 0
-        if x + w > max_width:
-            x = max_width - w
-        if y + h > max_height:
-            y = max_height - h
-
-        # set new limits
-        self.ax.set_xlim([x, x + w])
-        self.ax.set_ylim([y + h, y])
-        self.redraw()
-
-    def shift(self, dy, dx):
-        """Shifts the view with (dy, dx)"""
-        cur_xlim = self.ax.get_xlim()
-        cur_ylim = self.ax.get_ylim()
-        max_height, max_width = self.shape
-
-        x1 = cur_xlim[0] - dx
-        y1 = cur_ylim[1] - dy
-        x2 = cur_xlim[1] - dx
-        y2 = cur_ylim[0] - dy
-
-        if x1 < 0:
-            x2 -= x1
-            x1 = 0
-        if y1 < 0:
-            y2 -= y1
-            y1 = 0
-        if x2 > max_width:
-            x1 -= (x2 - max_width)
-            x2 = max_width
-        if y2 > max_height:
-            y1 -= (y2 - max_height)
-            y2 = max_height
-
-        # set new limits
-        self.ax.set_xlim([x1, x2])
-        self.ax.set_ylim([y2, y1])
-        self.redraw()
-
-    def center(self, y, x):
-        """Centers the view on (y, x)"""
-        cur_xlim = self.ax.get_xlim()
-        cur_ylim = self.ax.get_ylim()
-        self.shift((cur_ylim[0] + cur_ylim[1]) / 2 - y,
-                   (cur_xlim[0] + cur_xlim[1]) / 2 - x)
-
-    def on_press(self, event):
-        if event.inaxes != self.ax:
-            return
-        if event.button == 1 and event.dblclick:  # double click: center
-            self.center(event.ydata, event.xdata)
-
     def on_motion(self, event):
         try:
             x = int(event.xdata + 0.5)
@@ -191,17 +102,14 @@ class Display(object):
     def on_scroll(self, event):
         if event.inaxes != self.ax:
             return
-        if self.control_is_held:
-            self.zoom(event.step, (event.ydata, event.xdata))
         elif 'z' in self.viewer.sizes:
             self.viewer.set_index(self.viewer.index['z'] - int(event.step), 'z')
 
-    def toggle_control_key(self):
-        self.control_is_held = not self.control_is_held
 
 class Display_MIP(Display):
     name = 'Max intensity projection'
     ndim = 3
+
     def __init__(self, viewer, shape):
         super(Display_MIP, self).__init__(viewer, shape[1:])
 

--- a/pimsviewer/display.py
+++ b/pimsviewer/display.py
@@ -47,8 +47,6 @@ class Display(object):
         self.canvas.mpl_connect('motion_notify_event', self.on_motion)
         self.canvas.mpl_connect('button_press_event', self.on_press)
         self.canvas.mpl_connect('scroll_event', self.on_scroll)
-        self.canvas.mpl_connect('key_press_event', self.on_key_press)
-        self.canvas.mpl_connect('key_release_event', self.on_key_release)
 
         self.canvas.setFocusPolicy(Qt.ClickFocus)
         self.canvas.setFocus()
@@ -198,14 +196,8 @@ class Display(object):
         elif 'z' in self.viewer.sizes:
             self.viewer.set_index(self.viewer.index['z'] - int(event.step), 'z')
 
-    def on_key_press(self, event):
-        if event.key == 'control':
-            self.control_is_held = True
-
-    def on_key_release(self, event):
-        if event.key == 'control':
-            self.control_is_held = False
-
+    def toggle_control_key(self):
+        self.control_is_held = not self.control_is_held
 
 class Display_MIP(Display):
     name = 'Max intensity projection'

--- a/pimsviewer/qt.py
+++ b/pimsviewer/qt.py
@@ -1,3 +1,13 @@
 from skimage.viewer.qt import (Qt, QtWidgets, QtGui, QtCore, Signal,
                                _qt_version, has_qt, FigureCanvasQTAgg)
 from skimage.viewer.utils import init_qtapp, start_qtapp
+from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+
+
+class NavigationToolbar(NavigationToolbar2QT):
+    # only display the buttons we need
+    toolitems = [t for t in NavigationToolbar2QT.toolitems if
+                 t[0] in ('Home', 'Back', 'Forward', 'Pan', 'Zoom')]
+
+    def __init__(self, canvas, parent):
+        super().__init__(canvas, parent, coordinates=False)

--- a/pimsviewer/qt.py
+++ b/pimsviewer/qt.py
@@ -1,6 +1,8 @@
 from skimage.viewer.qt import (Qt, QtWidgets, QtGui, QtCore, Signal,
                                _qt_version, has_qt, FigureCanvasQTAgg)
 from skimage.viewer.utils import init_qtapp, start_qtapp
+from PyQt5.QtWidgets import QShortcut
+from PyQt5.QtGui import QKeySequence
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
 

--- a/pimsviewer/viewer.py
+++ b/pimsviewer/viewer.py
@@ -728,6 +728,8 @@ class Viewer(QtWidgets.QMainWindow):
                 self.resize_display(factor=1)
             elif key == Qt.Key_D:
                 self.resize_display(factor=2)
+            elif key == Qt.Key_Control:
+                self._display.toggle_control_key()
             else:
                 event.ignore()
         else:

--- a/pimsviewer/viewer.py
+++ b/pimsviewer/viewer.py
@@ -19,7 +19,7 @@ from pims import export
 
 from .widgets import CheckBox, DockWidget, VideoTimer, Slider
 from .qt import (Qt, QtWidgets, QtGui, QtCore, Signal,
-                 init_qtapp, start_qtapp)
+                 init_qtapp, start_qtapp, NavigationToolbar)
 from .display import Display
 from .utils import (wrap_frames_sequence, recursive_subclasses,
                     to_rgb_uint8, memoize, get_supported_extensions, drop_dot, get_available_readers)
@@ -177,6 +177,8 @@ class Viewer(QtWidgets.QMainWindow):
         self.setSizePolicy(QtWidgets.QSizePolicy.Preferred,
                            QtWidgets.QSizePolicy.Preferred)
         self.main_layout = QtWidgets.QGridLayout(self.main_widget)
+
+        self.mpl_toolbar = None
 
         # make file dragging & dropping work
         self.setAcceptDrops(True)
@@ -392,7 +394,9 @@ class Viewer(QtWidgets.QMainWindow):
         self.canvas.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
                                   QtWidgets.QSizePolicy.Expanding)
         self.canvas.updateGeometry()
-        self.main_layout.addWidget(self.canvas, 0, 0)
+        self.mpl_toolbar = NavigationToolbar(self.canvas, self.main_widget)
+        self.main_layout.addWidget(self.mpl_toolbar, 0, 0)
+        self.main_layout.addWidget(self.canvas, 1, 0)
         self.canvas.keyPressEvent = self.keyPressEvent
         self.update_original_image()
 
@@ -709,15 +713,6 @@ class Viewer(QtWidgets.QMainWindow):
                 self._display.set_fullscreen()
             elif key == Qt.Key_Escape:
                 self._display.set_fullscreen(False)
-            elif key == Qt.Key_Plus:
-                if hasattr(self._display, 'zoom'):
-                    self._display.zoom(1)
-            elif key == Qt.Key_Minus:
-                if hasattr(self._display, 'zoom'):
-                    self._display.zoom(-1)
-            elif key == Qt.Key_0:
-                if hasattr(self._display, 'zoom'):
-                    self._display.zoom()
             elif key == Qt.Key_Z:
                 self.undo.emit()
             elif key == Qt.Key_Y:
@@ -728,8 +723,6 @@ class Viewer(QtWidgets.QMainWindow):
                 self.resize_display(factor=1)
             elif key == Qt.Key_D:
                 self.resize_display(factor=2)
-            elif key == Qt.Key_Control:
-                self._display.toggle_control_key()
             else:
                 event.ignore()
         else:


### PR DESCRIPTION
I have implemented a standard Matplotlib navigation/zooming toolbar which now also makes zooming to a rectangle, and navigating between next/previous zoom levels possible.

Additionally, I have cleaned up the keypress code to only register shortcuts in the main window and not on the canvas (because if canvas loses focus, the keys don't get processed).