### PR TITLE
Misc frame rate improvements

### DIFF
--- a/pimsviewer/dimension.py
+++ b/pimsviewer/dimension.py
@@ -14,6 +14,7 @@ class Dimension(QWidget):
     _merge = False
     _playable = False
     _fps = 5.0
+    _max_playback_fps = 5.0
 
     play_event = pyqtSignal(QWidget)
 
@@ -106,7 +107,10 @@ class Dimension(QWidget):
         if not self.playing:
             return
 
-        self.position += 1
+        if self._fps > self._max_playback_fps:
+            self.position += int(round(self._fps / self._max_playback_fps))
+        else:
+            self.position += 1
 
     @property
     def size(self):
@@ -129,7 +133,8 @@ class Dimension(QWidget):
         fps = float(fps)
 
         self._fps = fps
-        self.playTimer.setInterval(int(round(1000.0 / self._fps)))
+        play_fps = fps if fps < self._max_playback_fps else self._max_playback_fps
+        self.playTimer.setInterval(int(round(1000.0 / play_fps)))
         self.fpsButton.setText('%d fps' % self.fps)
 
     @property

--- a/pimsviewer/gui.py
+++ b/pimsviewer/gui.py
@@ -270,6 +270,12 @@ class GUI(QMainWindow):
 
         self.reader.bundle_axes = bundle_axes
 
+        if 't' in self.dimensions:
+            try:
+                self.dimensions['t'].fps = self.reader.frame_rate
+            except AttributeError:
+                self.statusbar.showMessage('Unable to read frame rate from file')
+
     def get_current_frame(self):
         self.reader.bundle_axes = 'xy'
         default_coords = {}

--- a/pimsviewer/gui.py
+++ b/pimsviewer/gui.py
@@ -127,6 +127,19 @@ class GUI(QMainWindow):
             html = '<p><strong>%s:</strong></p><p><pre>%s</pre></p>' % (prop, self.reader.metadata[prop])
             items.append(html)
 
+        try:
+            html = '<p><strong>Framerate:</strong></p><p><pre>%.3f</pre></p>' % (self.reader.frame_rate)
+            items.append(html)
+            num_frames = self.reader.sizes['t']
+            html = '<p><strong>Duration:</strong></p><p><pre>%.3f s</pre></p>' % (num_frames / self.reader.frame_rate)
+            items.append(html)
+        except (AttributeError):
+            html = '<p><strong>Framerate:</strong></p><p><pre>Unknown</pre></p>'
+            items.append(html)
+            num_frames = self.reader.sizes['t']
+            html = '<p><strong>Duration:</strong></p><p><pre>%d frames</pre></p>' % (num_frames)
+            items.append(html)
+
         # File path
         html = '<p><strong>Filename:</strong></p><p>%s</p>' % (self.filename)
         items.append(html)


### PR DESCRIPTION
- Add frame rate and duration to file information dialog
- Use a maximum playback frame rate of 5 fps, higher frame rates lead to skipping some frames to ensure smooth playback
- Try to read the frame rate from the current file reader 